### PR TITLE
fixed mjd shape + bias/reso mjd prior ranges

### DIFF
--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -97,14 +97,15 @@ Parameters
     
 end
 
-function gaussian_plus_lowEtail(evt_energy::Float64,Qbb::Float64,bias::Float64,part_k::NamedTuple,fit_range)
+function gaussian_plus_lowEtail(evt_energy::Float64,Qbb::Float64,bias::Float64,reso::Float64,part_k::NamedTuple,fit_range)
 """
 Signal model based on the peak shape used for the MJD analysis. The peak shape derives from considerations made in [S. I. Alvis et al., Phys. Rev. C 100, 025501 (2019)].
 """
+    γ = reso
+    # following params are ALWAYS fixed
     f = part_k.frac
     τ = part_k.tau
     σ = part_k.sigma
-    γ = part_k.width
     
     term1 = (1-f) * pdf(Normal(Qbb-bias, γ*σ), evt_energy)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -102,7 +102,6 @@ function get_partitions_new(part_path::String)
         end
     
         #TODO: find a way to make this not hardcoded
-        #NOTE: "*1.0" helps converting into floats
         tab = Table(experiment=Array(arrays["experiment"]),
                     fit_group=Array(arrays["fit_group"]),
                     bkg_name = Array(arrays["bkg_par_name"]),
@@ -114,16 +113,16 @@ function get_partitions_new(part_path::String)
                     part_name=Array(arrays["part_name"]),
                     start_ts=Array(arrays["start_ts"]),
                     end_ts=Array(arrays["end_ts"]),
-                    eff_tot=Array(arrays["eff_tot"]*1.0),
-                    eff_tot_sigma=Array(arrays["eff_tot_sigma"]*1.0),
-                    width=Array(arrays["width"]*1.0),
-                    width_sigma=Array(arrays["width_sigma"]*1.0),
-                    exposure=Array(arrays["exposure"]*1.0),
-                    bias =Array(arrays["bias"]*1.0),
-                    bias_sigma =Array(arrays["bias_sigma"]*1.0),
-                    frac =Array(arrays["frac"]*1.0),
-                    tau =Array(arrays["tau"]*1.0),
-                    sigma =Array(arrays["sigma"]*1.0))
+                    eff_tot=Array(arrays["eff_tot"]),
+                    eff_tot_sigma=Array(arrays["eff_tot_sigma"]),
+                    width=Array(arrays["width"]),
+                    width_sigma=Array(arrays["width_sigma"]),
+                    exposure=Array(arrays["exposure"]),
+                    bias =Array(arrays["bias"]),
+                    bias_sigma =Array(arrays["bias_sigma"]),
+                    frac =Array(arrays["frac"]),
+                    tau =Array(arrays["tau"]),
+                    sigma =Array(arrays["sigma"]))
         return tab,fit_groups,fit_ranges
 end
 


### PR DESCRIPTION
- γ  can be fixed or not, so it has to be retrieved via a dedicated function
- bias/reso priors had too large ranges and the fit was crashing -> adopted a +-5sigma range, defining resolution as positive (but not biases, since they are centred around 0 and they can fluctuate to negative values as well)