### PR TITLE
excluded events out of additional exclusion bands

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,10 @@ on:
       - 'releases/**'
     tags: '*'
   pull_request:
+    branches:
+      - main
+      - dev
+      - 'releases/**'
   release:
 
 concurrency:
@@ -61,3 +65,4 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
+

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -133,6 +133,7 @@ function plot_data(
         return model
     end
 
+    # plot fit over data + CI band
     if plotflag["bandfit_and_data"]
         plot!(
             p,
@@ -165,8 +166,7 @@ function plot_data(
         )
     end
 
-    # exclude the gamma lines
-    ### TO DO -> GENERALIZE TO WHATEVER REMOVED INTERVAL WITHIN THE MIN-MAX OF fit_ranges 
+    # exclude gamma lines
     shape_x = [
         constants.gamma_2113_keV,
         constants.gamma_2113_keV,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -176,6 +176,22 @@ end
 
 
 """
+    event_is_contained(event::Float64, fit_ranges)
+    
+Returns true if the event is contained at least in one of the energy ranges
+"""
+function event_is_contained(event::Float64, fit_range)::Bool
+    flag = false
+    for range_pair in fit_range
+        if range_pair[1] <= event <= range_pair[2]
+            flag = true
+        end
+    end
+    return flag 
+end 
+
+    
+"""
     get_partitions_events(config::Dict{String, Any})
     
 Get partition, event, and fit range info from input JSON files
@@ -194,11 +210,16 @@ function get_partitions_events(config::Dict{String,Any})
     events = Array{Vector{Float64}}(undef, length(partitions))
     for i = 1:length(partitions)
 
+        # get fit group (each one has its own fit range) 
+        fit_group = partitions[i].fit_group
+        fit_range = fit_ranges[fit_group]
         arr_tmp = Vector{Float64}()
         for sub in events_multi
             if (sub[i] != Float64[])
-
-                append!(arr_tmp, sub[i])
+                # check if the event is contained in the given fit range
+                if event_is_contained(sub[i][1], fit_range)
+                    append!(arr_tmp, sub[i])
+                end
             end
         end
 
@@ -225,7 +246,6 @@ This creates a vector where
 
 where the index counts the number of partitions with index<=i with, 
 events and corresponds to the index of the parameters.
-
 """
 function get_partition_event_index(
     events::Array{Vector{Float64}},

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -187,10 +187,10 @@ function event_is_contained(event::Float64, fit_range)::Bool
             flag = true
         end
     end
-    return flag 
-end 
+    return flag
+end
 
-    
+
 """
     get_partitions_events(config::Dict{String, Any})
     

--- a/test/io/test_all.jl
+++ b/test/io/test_all.jl
@@ -10,4 +10,5 @@ Test.@testset "io" begin
     include("test_get_signal_prior_info.jl")
     include("test_get_energy_scale_pars.jl")
     include("test_get_efficiency.jl")
+    include("test_event_is_contained.jl")
 end

--- a/test/io/test_event_is_contained.jl
+++ b/test/io/test_event_is_contained.jl
@@ -1,0 +1,33 @@
+using Pkg
+Pkg.activate(".") # activate the environment
+Pkg.instantiate() # instantiate the environment
+include("../../src/ZeroNuFit.jl")
+using .ZeroNuFit
+include("../../main.jl")
+include("../../src/utils.jl")
+
+@testset "" begin
+
+    @info "Testing function to flag if an event is contained or not in the fit ranges (function 'event_is_contained' in src/utils.jl)"
+    fit_range = [[1930.0, 2098.511], [2108.511, 2113.513], [2123.513, 2190.0]]
+
+    # contained event
+    event = 1950.0
+    flag = nothing
+    try
+        flag = ZeroNuFit.event_is_contained(event, fit_range)
+    catch e
+        @error "Error in event_is_contained: $e"
+        throw(e)
+    end
+
+    @testset "Check flag is valid" begin
+        @test !isnothing(flag)
+    end
+    @test flag == true
+
+    # event outside fit window
+    event = 150.0
+    flag = ZeroNuFit.event_is_contained(event, fit_range)
+    @test flag == false
+end


### PR DESCRIPTION
previously there was no check in the containment of events in the fit ranges, we were relying on input JSON files where these events are already not present. However, during some test fits, we noticed that data that was supposed to be blinded a posteriori were still contributing to the fit. 